### PR TITLE
Remove mac check from GitHub actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        - macOS-latest  # https://github.com/embulk/embulk-parser-csv/issues/4
         - windows-latest
 
     steps:


### PR DESCRIPTION
Mac-latest in github-actions no longer supports OpenJDK8. So Mac-latest may be removed from github actions.